### PR TITLE
fix: Edit button switches theme, cap drawer height so page shows below

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -82,7 +82,7 @@ body {
 
 /* ── SETTINGS DRAWER ─────────────────────── */
 .settings-drawer {
-  position: fixed; top: 0; right: -340px; width: 320px; height: 100vh;
+  position: fixed; top: 0; right: -340px; width: 320px; height: auto; max-height: calc(100vh - 56px);
   background: var(--bg2); border-left: 1px solid var(--border);
   z-index: 500; display: flex; flex-direction: column;
   transition: right 0.28s cubic-bezier(0.4, 0, 0.2, 1);

--- a/js/theme.js
+++ b/js/theme.js
@@ -429,6 +429,7 @@ function settingsToggleExpand(key) {
   document.querySelectorAll('.str-expand').forEach(e => e.classList.remove('open'));
   document.querySelectorAll('.str-edit-btn').forEach(b => b.textContent = 'Edit ▾');
   if (!isOpen) {
+    setTheme(key);
     el.classList.add('open');
     const btn = el.closest('.settings-theme-row').querySelector('.str-edit-btn');
     if (btn) btn.textContent = 'Edit ▴';


### PR DESCRIPTION
Fixes two bugs in the Color Mode theme drawer.

**Bug 1 (theme.js):** Clicking the Edit button on a theme row expanded the panel but did not switch the active theme. Added `setTheme(key)` to `settingsToggleExpand()` so clicking Edit behaves the same as clicking the row.

**Bug 2 (styles.css):** The Color Mode drawer used `height: 100vh`, taking up the full screen and making it impossible to click outside to dismiss. Changed to `height: auto; max-height: calc(100vh - 56px)` so the drawer ends just below the nav and the page is visible and clickable beneath it.

Closes #37