### PR TITLE
chore: update README for Mar 23 session

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Personal guitar practice dashboard. Vanilla HTML/CSS/JS, deployed to AWS S3 + Cl
 ```
 thefretshed/
 ├── index.html
+├── login.html          ← password gate, sets userId in sessionStorage
 ├── css/
 │   └── styles.css
 ├── js/
@@ -24,9 +25,12 @@ thefretshed/
 │   ├── viewport.js     ← admin viewport preview
 │   ├── init.js         ← entry point (init())
 │   ├── data.js         ← all curriculum/song/gear content — edit here
+│   ├── progress.js     ← DynamoDB progress API (sessions, songs, books, milestones)
 │   ├── spotify.js      ← Spotify OAuth + search + inline player
 │   └── claude.js       ← Claude AI integration (stub)
 ├── images/             ← gear images (hardcoded in index.html)
+├── scripts/
+│   └── setup-dynamodb.mjs  ← one-time DynamoDB table provisioning script
 ├── tests/
 │   └── streak.test.js  ← Vitest tests for calcStreaks
 ├── .github/
@@ -46,14 +50,6 @@ npm install       # first time only
 npm start         # serves at http://localhost:3000
 npm test          # runs Vitest test suite
 npm run test:watch  # runs tests in watch mode
-```
-
-**Standard test-before-merge workflow:**
-```bash
-git checkout fix/your-branch-name   # switch to the branch being tested
-npm start                           # serves at http://localhost:3000
-# test in browser, Ctrl+C to stop
-# if good → open PR on GitHub and merge → auto-deploys
 ```
 
 ---
@@ -87,8 +83,14 @@ then checks open Issues on the project board before any work begins.
 - Uses Desktop Commander (`allowedDirectories: /Users/christophervoss/Documents/thefretshed`)
 - Edits files directly in the local repo via `edit_block`
 - Creates branch, commits, and pushes via `start_process` (git CLI)
-- Opens PR via Claude in Chrome browser automation
+- Opens PR via GitHub REST API using PAT stored at `~/.thefretshed-mcp-env`
 - Merges PR → CI runs → auto-deploys to S3 + CloudFront
+
+**GitHub writes (issues, PRs):**
+- GitHub MCP connector is read-only — write ops return 403
+- Workaround: PAT + GitHub REST API via bash_tool
+- PAT stored at `~/.thefretshed-mcp-env` (chmod 600) — never commit this file
+- Usage: `source ~/.thefretshed-mcp-env && curl -X POST ... -H "Authorization: Bearer $GITHUB_TOKEN"`
 
 **Key principles:**
 - Collect → plan → build. Confirm approach before writing code.
@@ -96,9 +98,28 @@ then checks open Issues on the project board before any work begins.
 - All backlog items tracked as GitHub Issues. No verbal backlogs.
 - README updated at end of every session as the handoff artifact.
 
-**Known limitation:** The built-in GitHub connector in Claude.ai (Settings → Connectors) is
-OAuth read-context only — it does not give Claude tool-callable API access. Full automation
-(create issues, push files without local repo) requires the custom GitHub MCP server (Issue #36).
+---
+
+## Auth & Progress Architecture
+
+**Login:** `login.html` — hardcoded credentials per user. On success, sets `userId` in
+`sessionStorage`. `index.html` redirects to login if no session found.
+Designed to swap to Cognito (#31) without redesigning the UI.
+
+**Users:** defined in `USERS` object in `login.html`. Add entries manually to grant access.
+
+**Progress storage:** All progress data lives in DynamoDB (`thefretshed-progress` table).
+`localStorage` is used only for UI preferences (theme, Spotify token/cache).
+
+**progress.js API:**
+- `saveSession(blocksCompleted, notes)` — save today's session
+- `loadAllSessions()` — all sessions for streak/heatmap
+- `savePosition(week, phase)` / `loadPosition()` — curriculum position
+- `saveSongStatus(title, status)` / `loadAllSongStatuses()` — song progress
+- `saveBookChapter(bookKey, chapter)` / `loadBookProgress(bookKey)` — book completions
+- `saveMilestone(id)` / `loadAllMilestones()` — milestone tracking
+- `calcStreakFromBackend()` — streak derived from session records
+- `saveNotes(notes)` / `loadTodayNotes()` — session notes
 
 ---
 
@@ -120,7 +141,7 @@ OAuth read-context only — it does not give Claude tool-callable API access. Fu
 
 **Session card:** blocks (1.6fr) | timer+metro (1fr), left-bordered separator.
 
-**Viewport preview (Settings → Admin):** Desktop (full dynamic) / Tablet (1024px) / Phone (390px). On mobile/tablet preview, week buttons reflow to 2 rows of 6.
+**Viewport preview (Settings → Admin):** Desktop (full dynamic) / Tablet (1024px) / Phone (390px).
 
 ---
 
@@ -145,13 +166,12 @@ Each phase has expandable song workspace cards with:
 - Skill tags
 - Action buttons: Spotify (inline player toggle) · Tab (UG link) · Tone (popover)
 
-**Spotify inline player:** clicking Spotify button searches for the track and embeds a compact 80px iframe player. Toggle to collapse. Falls back to Spotify search in new tab if not connected. Track IDs cached in localStorage.
-
 ---
 
-## localStorage Keys
+## localStorage Keys (UI prefs only — progress is in DynamoDB)
 
-`ngc-theme` · `ngc-preset-{theme}` · `ngc-custom-{theme}` · `ngc-week` · `ngc-block-{date}-{plan}-{idx}` · `ngc-practice-days` · `ngc-notes` · `ngc-checks` · `ngc-milestones` · `ngc-gear-url-{id}` · `ngc-song-status-{title}` · `ngc-viewport-preview` · `ngc-spotify-token` · `ngc-spotify-expiry` · `ngc-spotify-track-{slug}`
+`ngc-theme` · `ngc-preset-{theme}` · `ngc-custom-{theme}` · `ngc-viewport-preview`
+`ngc-spotify-token` · `ngc-spotify-expiry` · `ngc-spotify-track-{slug}`
 
 ---
 
@@ -162,78 +182,64 @@ Each phase has expandable song workspace cards with:
 - CloudFront distribution → S3 website endpoint
 - ACM SSL cert (us-east-1) — auto-validated via Route 53
 - Route 53 A alias records → CloudFront
-- IAM user: `thefretshed-deploy` — S3 sync + CloudFront invalidation
+- IAM user: `thefretshed-deploy` — S3 sync + CloudFront invalidation + DynamoDB + Lambda
 - GitHub secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `CLOUDFRONT_DISTRIBUTION_ID`
 
 **Deploy workflow:** push to `main` → GitHub Actions syncs to S3 + invalidates CloudFront (`/*`). No manual steps.
 
+### Progress Database
+- DynamoDB table: `thefretshed-progress` (us-east-1, PAY_PER_REQUEST)
+- Partition key: `userId` (string) · Sort key: `sk` (string)
+- SK patterns: `SESSION#YYYY-MM-DD` · `SONG#title` · `BOOK#key#chapter` · `MILESTONE#id` · `POSITION`
+
 ### Content (PDFs + Audio)
 Private S3 bucket: `thefretshed-content`
-- `books/` — curriculum PDFs
-- `audio/` — lesson MP3s
+- `books/` — curriculum PDFs · `audio/` — lesson MP3s
 
 IAM user: `thefretshed-content-user`
-Policy: `TheFretShedContentAccess` (s3:GetObject + s3:ListBucket on thefretshed-content/*)
-Lambda: `getFretShedContentUrl` — two routes:
-- `GET /get-url?key=books/filename.pdf` — generates pre-signed URL (1hr expiry)
-- `GET /list-folder?prefix=audio/folder-name/` — lists all objects under a prefix
-API Gateway: `thefretshed-content-api` — HTTP API, auto-deploy enabled on `$default` stage
+Lambda: `getFretShedContentUrl` — routes:
+- `GET /get-url?key=` — pre-signed URL (1hr expiry)
+- `GET /list-folder?prefix=` — list objects under prefix
+- `GET /progress?userId=&sk=` — fetch single progress record
+- `PUT /progress` — write progress record (body: `{ userId, sk, ...data }`)
+- `GET /progress/list?userId=&skPrefix=` — list records by prefix
+
+API Gateway: `thefretshed-content-api` — HTTP API, auto-deploy on `$default` stage
 
 ---
 
 ## GitHub Project Board
 
-**The Fret Shed** project board at github.com/consumethetangible/thefretshed/projects
-
 Columns: Backlog → Ready → In Progress → **Bugs** → Done
 
 Labels: `bug` · `ux` · `feature` · `engineering` · `data` · `investigate` · `priority-1` · `priority-2` · `priority-3` · `priority-4`
 
-All backlog items are filed as Issues with labels and priority. Promote issues from Backlog → Ready before starting work. Active bugs and defects go in the **Bugs** column.
+---
+
+## Priority 1 Queue
+
+| # | Issue | Status |
+|---|---|---|
+| #46 | Epic: Unified Session + Progress Tracking | 🔵 In Progress |
+| #47 | DynamoDB backend + data schema | ✅ Done (PR #53) |
+| #48 | Login page — simple password gate | ✅ Done (PR #53) |
+| #49 | Unified Session View | 🔲 Next |
+| #50 | Book/exercise progress tracking | 🔲 Queued |
+| #51 | Milestone auto-calculation | 🔲 Queued |
+| #52 | Progress history + streak from backend | 🔲 Queued |
+| #6  | Site logo + browser favicon | 🔲 After epic |
 
 ---
 
 ## Gear
 
-**Guitars:** Fender American Professional II Stratocaster, Gibson Les Paul Deluxe 70s Goldtop, Gibson Les Paul Studio Faded T 2016, Chapman ML3 Pro Bea, Yamaha Pacifica PAC611HFM, Martin SC-10E
+**Guitars:** Fender American Professional II Stratocaster, Gibson Les Paul Deluxe 70s Goldtop,
+Gibson Les Paul Studio Faded T 2016, Chapman ML3 Pro Bea, Yamaha Pacifica PAC611HFM, Martin SC-10E
 
 **Amps:** Fender Blues Jr. 4 Tweed, Bugera 1990 Infinium 120W Head, Boss Katana Mk1 100W combo
 
-**Gear images:** Hardcoded in `index.html` via `images/` folder — no localStorage dependency. To update an image, replace the file in `images/` and push.
-
 ---
 
-## Known Issues (Active Bugs)
-
-Tracked in GitHub Issues under the **Bugs** column on the project board.
-
-| # | Issue | Status |
-|---|---|---|
-| #37 | Settings Color Mode dropdown hardcoded to "Dark" | Fixed, merged |
-| #39 | Color Mode Edit button doesn't switch theme; drawer full-screen height | Fixed, merged |
-| — | Settings drawer missing bottom border + wrong top offset | Fixed, merged |
-| #2 | Fix Light Mode — broken/hard to use | Fixed, merged |
-| #3 | Settings panel reorganization | Fixed, merged |
-| #4 | Easier way to exit Settings | Fixed, merged |
-
----
-
-## Next Up — Priority 1 UX Fixes
-
-All tracked as GitHub Issues with `priority-1` label. Work in this order:
-
-1. **#5** Secure login page
-2. **#6** Site logo + browser favicon
-
----
-
-## Engineering Backlog
-
-| # | Item | Status |
-|---|---|---|
-| — | Split curriculum.js (1100+ lines) | Open |
-| — | Expand Vitest coverage beyond streak module | Open |
-
----
-
-*Last updated: Mar 20, 2026 — Session 2. Fixed settings drawer border + top offset. Rebuilt Light theme palettes (proper bg layering, high contrast, cool neutral Cream default). Settings panel reorganized: Preferences first (with Audio merged in), Spotify, Data Management, Admin, App Info last. Gear icon now toggles settings open/close. Color Mode Save button closes picker and returns to Settings. Overlay dim added. VERSION constant added to theme.js (now at 2.1). Close #2, #3, #4 manually in GitHub. Next: #5 Secure login page, #6 Logo + favicon.*
+*Last updated: Mar 23, 2026 — DynamoDB backend provisioned, Lambda progress routes deployed,
+progress.js API layer added, login.html live and tested (PR #53 merged). GitHub write ops
+handled via PAT + REST API (MCP connector is read-only). Next: #49 Unified Session View.*


### PR DESCRIPTION
Updates README to reflect current state:
- DynamoDB backend + progress.js API layer
- Login page architecture
- GitHub write ops via PAT + REST API
- Updated Priority 1 queue
- Updated localStorage keys (UI prefs only)
- Updated Lambda routes