### PR TITLE
feat: practice modal (#49)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1829,3 +1829,226 @@ select.shed-s-itf { border-color: var(--status-itf); color: var(--status-itf); }
   color: #f5c518 !important;
 }
 .shed-btn-ug:hover { background: #2a2a2a !important; border-color: #444 !important; }
+
+
+/* ═══════════════════════════════════════════
+   PRACTICE MODAL
+   ═══════════════════════════════════════════ */
+
+.practice-modal-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0,0,0,0.6);
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+.practice-modal-backdrop.open {
+  display: flex;
+}
+.practice-modal {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  width: 100%;
+  max-width: 640px;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 24px;
+  position: relative;
+  box-sizing: border-box;
+}
+
+/* PM header */
+.pm-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+.pm-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pm-block-type {
+  font-size: 10px;
+  font-family: 'DM Mono', monospace;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-dim);
+  border-radius: 4px;
+  padding: 2px 7px;
+}
+.pm-duration {
+  font-size: 11px;
+  font-family: 'DM Mono', monospace;
+  color: var(--text2);
+}
+.pm-close-btn {
+  background: none;
+  border: none;
+  color: var(--text3);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 4px 6px;
+  line-height: 1;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+.pm-close-btn:hover { color: var(--text); background: var(--bg4); }
+
+/* PM title + detail */
+.pm-title {
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+.pm-detail {
+  font-size: 13px;
+  color: var(--text2);
+  line-height: 1.55;
+  margin-bottom: 16px;
+}
+
+/* PM content buttons (books, audio) */
+.pm-content-btns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+.pm-content-btns:empty { display: none; margin-bottom: 0; }
+.pm-book-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 7px 13px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  text-decoration: none;
+}
+.pm-book-btn:hover { background: var(--bg4); border-color: var(--accent); }
+.pm-book-btn .pm-btn-icon { font-size: 14px; }
+
+/* PM body: timer + metro two-column */
+.pm-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  margin-bottom: 20px;
+  align-items: start;
+}
+.pm-section-label {
+  font-size: 10px;
+  font-family: 'DM Mono', monospace;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text3);
+  margin-bottom: 12px;
+}
+.pm-timer-col, .pm-metro-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.pm-keep-practicing {
+  margin-top: 10px;
+}
+
+/* PM actions */
+.pm-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.pm-action-primary {
+  padding: 9px 20px;
+  border-radius: 6px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.pm-action-primary:hover { opacity: 0.88; }
+.pm-action-secondary {
+  padding: 9px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text2);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.pm-action-secondary:hover { background: var(--bg4); color: var(--text); }
+
+/* PM wrap-up state */
+.pm-wrapup {
+  border-top: 1px solid var(--border);
+  padding-top: 20px;
+  margin-top: 4px;
+}
+.pm-wrapup-title {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+.pm-wrapup-label {
+  font-size: 12px;
+  color: var(--text2);
+  margin-bottom: 10px;
+}
+.pm-notes-input {
+  width: 100%;
+  min-height: 80px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+  padding: 10px 12px;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: inherit;
+  margin-bottom: 12px;
+}
+.pm-notes-input:focus { outline: none; border-color: var(--accent); }
+.pm-wrapup-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+/* Block "come-back" state */
+.sblock.come-back {
+  border-left-color: var(--accent2, #c8883a) !important;
+  opacity: 0.75;
+}
+.sblock.come-back .sblock-head::after {
+  content: ' ↩';
+  font-size: 10px;
+  color: var(--accent2, #c8883a);
+}
+
+/* Responsive: stack timer/metro on narrow screens */
+@media (max-width: 480px) {
+  .pm-body { grid-template-columns: 1fr; }
+  .practice-modal { padding: 16px; }
+}

--- a/index.html
+++ b/index.html
@@ -536,6 +536,7 @@
   <!-- Application logic (split modules — load order matters) -->
   <script src="js/theme.js"></script>
   <script src="js/session.js"></script>
+  <script src="js/modal.js"></script>
   <script src="js/streak.js"></script>
   <script src="js/ui.js"></script>
   <script src="js/progress.js"></script>
@@ -562,6 +563,91 @@
     <button class="settings-drawer-close" onclick="closeSettings()" aria-label="Close">✕</button>
   </div>
   <div class="settings-drawer-body" id="settings-drawer-body"></div>
+</div>
+
+<!-- PRACTICE MODAL -->
+<div class="practice-modal-backdrop" id="practice-modal-backdrop" onclick="practiceModalBackdropClick(event)">
+  <div class="practice-modal" id="practice-modal" role="dialog" aria-modal="true">
+
+    <!-- Header -->
+    <div class="pm-header">
+      <div class="pm-header-left">
+        <span class="pm-block-type" id="pm-block-type"></span>
+        <span class="pm-duration" id="pm-duration"></span>
+      </div>
+      <button class="pm-close-btn" onclick="closePracticeModal()" aria-label="Close">✕</button>
+    </div>
+
+    <!-- Title + description -->
+    <div class="pm-title" id="pm-title"></div>
+    <div class="pm-detail" id="pm-detail"></div>
+
+    <!-- Content buttons (books, audio) -->
+    <div class="pm-content-btns" id="pm-content-btns"></div>
+
+    <!-- Main body: timer + metronome side by side -->
+    <div class="pm-body">
+
+      <!-- Timer column -->
+      <div class="pm-timer-col">
+        <div class="pm-section-label">Timer</div>
+        <div class="timer-ring-wrap">
+          <svg width="120" height="120" viewBox="0 0 130 130">
+            <circle class="timer-ring-bg" cx="65" cy="65" r="54" fill="none" stroke-width="6"/>
+            <circle class="timer-ring-fill" id="pm-timer-ring" cx="65" cy="65" r="54" fill="none" stroke-width="6" stroke-dasharray="339.3" stroke-dashoffset="0"/>
+          </svg>
+          <div class="timer-display">
+            <div class="timer-digits" id="pm-timer-digits">00:00</div>
+          </div>
+        </div>
+        <div class="timer-controls">
+          <button class="timer-btn timer-btn-secondary" onclick="pmTimerReset()">Reset</button>
+          <button class="timer-btn timer-btn-primary" id="pm-timer-start-btn" onclick="pmTimerToggle()">Start</button>
+          <button class="timer-btn timer-btn-secondary" onclick="pmTimerSkip()">Skip</button>
+        </div>
+        <div class="pm-keep-practicing" id="pm-keep-practicing" style="display:none">
+          <button class="pm-action-secondary" onclick="pmKeepPracticing()">+ 5 min more</button>
+        </div>
+      </div>
+
+      <!-- Metronome column -->
+      <div class="pm-metro-col">
+        <div class="pm-section-label">Metronome</div>
+        <div class="sm-bpm-row">
+          <button class="sm-nudge-btn" onclick="hmSetBpm(HM.bpm - 1);syncPmBpmInput()" oncontextmenu="event.preventDefault();hmSetBpm(HM.bpm - 5);syncPmBpmInput()">−</button>
+          <div class="sm-bpm-wrap">
+            <input class="sm-bpm-input" id="pm-bpm-input" type="number" min="40" max="240" value="100"
+              onchange="hmSetBpm(this.value);document.getElementById('sm-bpm-input').value=this.value"
+              oninput="hmSetBpm(this.value);document.getElementById('sm-bpm-input').value=this.value">
+            <span class="sm-bpm-unit">BPM</span>
+          </div>
+          <button class="sm-nudge-btn" onclick="hmSetBpm(HM.bpm + 1);syncPmBpmInput()" oncontextmenu="event.preventDefault();hmSetBpm(HM.bpm + 5);syncPmBpmInput()">+</button>
+        </div>
+        <div class="sm-metro-controls">
+          <button class="sm-btn sm-btn-tap" onclick="hmTap();syncPmBpmInput()">Tap</button>
+          <button class="sm-btn sm-btn-start" id="pm-metro-start-btn" onclick="hmToggle();syncPmMetroBtn()">Start</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Action row: normal practice state -->
+    <div class="pm-actions" id="pm-actions-normal">
+      <button class="pm-action-secondary" onclick="pmComeBack()">Come Back to This</button>
+      <button class="pm-action-primary" onclick="pmMarkComplete()">Mark Complete</button>
+    </div>
+
+    <!-- Wrap-up state (shown when last block completes) -->
+    <div class="pm-wrapup" id="pm-wrapup" style="display:none">
+      <div class="pm-wrapup-title">Session done — nice work.</div>
+      <div class="pm-wrapup-label">Add a note before you go?</div>
+      <textarea class="pm-notes-input" id="pm-notes-input" placeholder="What clicked today? What needs work?"></textarea>
+      <div class="pm-wrapup-actions">
+        <button class="pm-action-secondary" onclick="pmSkipNotes()">Skip Notes</button>
+        <button class="pm-action-primary" onclick="pmSaveAndFinish()">Save &amp; Finish</button>
+      </div>
+    </div>
+
+  </div>
 </div>
 
 <!-- THEME PICKER DRAWER (Mode button) -->

--- a/js/init.js
+++ b/js/init.js
@@ -37,6 +37,7 @@ function init() {
 
   // New: restore block states and build streak
   restoreBlockStates();
+  stampBlockRefs();
   buildStreakCard();
   // Restore completion banner if today was already done
   checkSessionComplete();

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,0 +1,320 @@
+// ═══════════════════════════════════════════
+// modal.js — Practice Modal
+// Opens when a session block is clicked.
+// Owns its own timer state (PM_TIMER) so it
+// doesn't conflict with the dashboard timer.
+// ═══════════════════════════════════════════
+
+// ─── State ───────────────────────────────────────────────────────────────────
+const PM = {
+  planId:   null,   // 'high' | 'low' | 'weekend'
+  blockIdx: null,   // integer
+  blockEl:  null,   // DOM element reference
+  blockType: null,  // css class name e.g. 'warmup'
+};
+
+const PM_TIMER = {
+  totalSecs: 0,
+  remainSecs: 0,
+  running: false,
+  interval: null,
+};
+const PM_CIRCUMFERENCE = 2 * Math.PI * 54;
+
+// ─── Open / Close ────────────────────────────────────────────────────────────
+
+function openPracticeModal(blockEl, planId, blockIdx) {
+  PM.planId   = planId;
+  PM.blockIdx = blockIdx;
+  PM.blockEl  = blockEl;
+
+  // Read block data from DOM
+  const timeEl   = blockEl.querySelector('.sblock-time');
+  const headEl   = blockEl.querySelector('.sblock-head');
+  const detailEl = blockEl.querySelector('.sblock-detail');
+  const mins     = parseInt(timeEl ? timeEl.textContent : '0') || 0;
+  const title    = headEl   ? headEl.textContent.trim()   : '';
+  const detail   = detailEl ? detailEl.textContent.trim() : '';
+
+  // Determine block type from classList for label colour
+  const typeClasses = ['warmup','theory','songs','ear','explore','licks'];
+  PM.blockType = typeClasses.find(c => blockEl.classList.contains(c)) || 'warmup';
+
+  // Populate header
+  document.getElementById('pm-block-type').textContent = PM.blockType;
+  document.getElementById('pm-duration').textContent   = mins + ' min';
+  document.getElementById('pm-title').textContent      = title;
+  document.getElementById('pm-detail').textContent     = detail;
+
+  // Build content buttons from block's data attributes (set by session.js at render)
+  buildPmContentBtns(planId, blockIdx);
+
+  // Initialise timer (not started)
+  pmTimerInit(mins);
+
+  // Sync metronome BPM display
+  document.getElementById('pm-bpm-input').value = HM.bpm;
+  syncPmMetroBtn();
+
+  // Reset to normal action row, hide wrapup
+  document.getElementById('pm-actions-normal').style.display = 'flex';
+  document.getElementById('pm-wrapup').style.display         = 'none';
+  document.getElementById('pm-keep-practicing').style.display = 'none';
+
+  // Open
+  document.getElementById('practice-modal-backdrop').classList.add('open');
+  document.body.style.overflow = 'hidden';
+}
+
+function closePracticeModal() {
+  pmTimerStop();
+  if (HM.running) hmStop();
+  document.getElementById('practice-modal-backdrop').classList.remove('open');
+  document.body.style.overflow = '';
+  PM.planId = PM.blockIdx = PM.blockEl = null;
+}
+
+function practiceModalBackdropClick(e) {
+  // Only close if clicking the backdrop itself, not the modal card
+  if (e.target === document.getElementById('practice-modal-backdrop')) {
+    closePracticeModal();
+  }
+}
+
+// Escape key support
+document.addEventListener('keydown', function(e) {
+  if (e.key === 'Escape' && document.getElementById('practice-modal-backdrop').classList.contains('open')) {
+    closePracticeModal();
+  }
+});
+
+// ─── Content Buttons ─────────────────────────────────────────────────────────
+// Block data is stored as dataset attributes on .sblock elements by session.js
+
+function buildPmContentBtns(planId, blockIdx) {
+  const container = document.getElementById('pm-content-btns');
+  container.innerHTML = '';
+
+  const plan  = document.getElementById('plan-' + planId);
+  if (!plan) return;
+  const block = plan.querySelectorAll('.sblock')[blockIdx];
+  if (!block) return;
+
+  // Book refs: stored as JSON in data-refs attribute
+  const refsJson = block.dataset.refs;
+  if (refsJson) {
+    try {
+      const refs = JSON.parse(refsJson);
+      refs.forEach(ref => {
+        const btn = document.createElement('button');
+        btn.className = 'pm-book-btn';
+        btn.innerHTML = '<span class="pm-btn-icon">📖</span>' + ref.label;
+        btn.onclick = () => openBookPdf(ref.book, btn);
+        container.appendChild(btn);
+      });
+    } catch(e) {}
+  }
+}
+
+// ─── Modal Timer ─────────────────────────────────────────────────────────────
+
+function pmTimerInit(mins) {
+  pmTimerStop();
+  PM_TIMER.totalSecs  = mins * 60;
+  PM_TIMER.remainSecs = mins * 60;
+  pmTimerRender();
+  document.getElementById('pm-timer-start-btn').textContent = 'Start';
+  document.getElementById('pm-timer-ring').style.strokeDashoffset = 0;
+  document.getElementById('pm-timer-ring').classList.remove('running','done');
+}
+
+function pmTimerStart() {
+  if (!PM_TIMER.totalSecs) return;
+  PM_TIMER.running = true;
+  document.getElementById('pm-timer-start-btn').textContent = 'Pause';
+  document.getElementById('pm-timer-ring').classList.add('running');
+  PM_TIMER.interval = setInterval(() => {
+    if (PM_TIMER.remainSecs <= 0) {
+      pmTimerComplete();
+    } else {
+      PM_TIMER.remainSecs--;
+      pmTimerRender();
+    }
+  }, 1000);
+}
+
+function pmTimerStop() {
+  PM_TIMER.running = false;
+  clearInterval(PM_TIMER.interval);
+  PM_TIMER.interval = null;
+  const btn = document.getElementById('pm-timer-start-btn');
+  if (btn) { btn.textContent = 'Start'; }
+  const ring = document.getElementById('pm-timer-ring');
+  if (ring) ring.classList.remove('running');
+}
+
+function pmTimerToggle() {
+  PM_TIMER.running ? pmTimerStop() : pmTimerStart();
+}
+
+function pmTimerReset() {
+  pmTimerStop();
+  PM_TIMER.remainSecs = PM_TIMER.totalSecs;
+  pmTimerRender();
+  document.getElementById('pm-timer-ring').classList.remove('done');
+  document.getElementById('pm-keep-practicing').style.display = 'none';
+}
+
+function pmTimerSkip() {
+  pmTimerStop();
+  PM_TIMER.remainSecs = 0;
+  pmTimerRender();
+  pmTimerComplete();
+}
+
+function pmTimerComplete() {
+  pmTimerStop();
+  PM_TIMER.remainSecs = 0;
+  pmTimerRender();
+  document.getElementById('pm-timer-ring').classList.add('done');
+  document.getElementById('pm-keep-practicing').style.display = 'block';
+  timerPing(false); // use existing audio ping from audio.js
+}
+
+function pmTimerRender() {
+  const m = Math.floor(PM_TIMER.remainSecs / 60);
+  const s = PM_TIMER.remainSecs % 60;
+  const digits = document.getElementById('pm-timer-digits');
+  if (digits) digits.textContent = String(m).padStart(2,'0') + ':' + String(s).padStart(2,'0');
+  const frac = PM_TIMER.totalSecs > 0 ? PM_TIMER.remainSecs / PM_TIMER.totalSecs : 0;
+  const ring = document.getElementById('pm-timer-ring');
+  if (ring) ring.style.strokeDashoffset = PM_CIRCUMFERENCE * (1 - frac);
+}
+
+function pmKeepPracticing() {
+  // Add 5 minutes and restart
+  PM_TIMER.totalSecs  += 5 * 60;
+  PM_TIMER.remainSecs += 5 * 60;
+  document.getElementById('pm-timer-ring').classList.remove('done');
+  document.getElementById('pm-keep-practicing').style.display = 'none';
+  pmTimerRender();
+  pmTimerStart();
+}
+
+// ─── Metronome sync helpers ───────────────────────────────────────────────────
+
+function syncPmMetroBtn() {
+  const btn = document.getElementById('pm-metro-start-btn');
+  if (!btn) return;
+  if (HM.running) {
+    btn.textContent = 'Stop';
+    btn.classList.add('active');
+  } else {
+    btn.textContent = 'Start';
+    btn.classList.remove('active');
+  }
+}
+
+function syncPmBpmInput() {
+  const input = document.getElementById('pm-bpm-input');
+  if (input) input.value = HM.bpm;
+}
+
+// ─── Block Actions ────────────────────────────────────────────────────────────
+
+function pmMarkComplete() {
+  if (PM.planId === null || PM.blockIdx === null) return;
+
+  // Stop timer + metro
+  pmTimerStop();
+  if (HM.running) hmStop();
+
+  // Mark the block done in session.js
+  markBlockComplete(PM.planId, PM.blockIdx);
+
+  // Remove come-back flag if set
+  if (PM.blockEl) PM.blockEl.classList.remove('come-back');
+
+  // Check if all blocks are now done (session complete)
+  const allDone = isSessionComplete(PM.planId);
+
+  if (allDone) {
+    pmShowWrapup();
+  } else {
+    closePracticeModal();
+  }
+}
+
+function pmComeBack() {
+  // Flag the block as started-but-incomplete
+  if (PM.blockEl) PM.blockEl.classList.add('come-back');
+  closePracticeModal();
+}
+
+// ─── Session Wrap-Up ─────────────────────────────────────────────────────────
+
+function pmShowWrapup() {
+  // Hide normal actions, show wrapup
+  document.getElementById('pm-actions-normal').style.display = 'none';
+  document.getElementById('pm-wrapup').style.display = 'block';
+
+  // Pre-populate with any existing notes for today
+  loadTodayNotes().then(existing => {
+    const area = document.getElementById('pm-notes-input');
+    if (area && existing) area.value = existing;
+  }).catch(() => {});
+}
+
+async function pmSaveAndFinish() {
+  const notes = document.getElementById('pm-notes-input').value.trim();
+  // Collect completed block labels for the session record
+  const blocksCompleted = getCompletedBlockLabels(PM.planId);
+  try {
+    await saveSession(blocksCompleted, notes);
+  } catch(e) {
+    console.warn('Session save failed:', e);
+  }
+  // Also save notes to notes card in dashboard if it exists
+  const notesEl = document.getElementById('session-notes');
+  if (notesEl && notes) notesEl.value = notes;
+  closePracticeModal();
+  // Show the session complete banner
+  checkSessionComplete();
+}
+
+async function pmSkipNotes() {
+  const blocksCompleted = getCompletedBlockLabels(PM.planId);
+  try {
+    await saveSession(blocksCompleted, '');
+  } catch(e) {
+    console.warn('Session save failed:', e);
+  }
+  closePracticeModal();
+  checkSessionComplete();
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function isSessionComplete(planId) {
+  const plan = document.getElementById('plan-' + planId);
+  if (!plan) return false;
+  const blocks = plan.querySelectorAll('.sblock');
+  if (!blocks.length) return false;
+  return [...blocks].every((_, idx) =>
+    localStorage.getItem(getBlockCheckKey(planId, idx)) === '1'
+  );
+}
+
+function getCompletedBlockLabels(planId) {
+  if (!planId) return [];
+  const plan = document.getElementById('plan-' + planId);
+  if (!plan) return [];
+  const labels = [];
+  plan.querySelectorAll('.sblock').forEach((block, idx) => {
+    if (localStorage.getItem(getBlockCheckKey(planId, idx)) === '1') {
+      const head = block.querySelector('.sblock-head');
+      if (head) labels.push(head.textContent.trim());
+    }
+  });
+  return labels;
+}

--- a/js/session.js
+++ b/js/session.js
@@ -20,29 +20,29 @@ function getBlockCheckKey(planId, blockIdx) {
 
 // ── 3-state block system: idle / active / complete ──
 
-// Clicking a block body activates it: highlights it and loads its duration into the timer
+// Stamp data-refs on each block so the modal can build content buttons.
+// Called once from init.js after DOM is ready.
+function stampBlockRefs() {
+  // Week refs come from PHASES[0].weeks[currentWeek-1].refs
+  // We map them onto the theory/book blocks by position.
+  // For now we attach current-week refs to any .theory block in the active plan.
+  try {
+    const phase = PHASES[0];
+    const weekIdx = Math.min(Math.floor((currentWeek - 1) / 2), phase.weeks.length - 1);
+    const week = phase.weeks[weekIdx];
+    if (!week || !week.refs || !week.refs.length) return;
+    const refsJson = JSON.stringify(week.refs);
+    document.querySelectorAll('.sblock.theory, .sblock.ear').forEach(block => {
+      block.dataset.refs = refsJson;
+    });
+  } catch(e) {}
+}
+
+// Clicking a block body opens the practice modal
 function activateBlock(blockEl, planId, blockIdx) {
-  const plan = document.getElementById('plan-' + planId);
-  if (!plan) return;
-
-  // Clear active from all blocks in this plan
-  plan.querySelectorAll('.sblock').forEach(b => b.classList.remove('active-block'));
-  blockEl.classList.add('active-block');
-
-  // Load this block's duration into the timer
-  const timeEl = blockEl.querySelector('.sblock-time');
-  const headEl = blockEl.querySelector('.sblock-head');
-  if (timeEl && headEl) {
-    const mins = parseInt(timeEl.textContent);
-    if (!isNaN(mins)) {
-      timerStop();
-      TIMER.segments = [{ label: headEl.textContent.trim(), minutes: mins }];
-      TIMER.segIdx = 0; TIMER.doneSegs.clear();
-      timerInitSeg(); timerRenderSegs();
-      const lbl = document.getElementById('timer-mode-label');
-      if (lbl) lbl.textContent = headEl.textContent.trim().substring(0, 22);
-    }
-  }
+  // Don't open if already completed
+  if (blockEl.classList.contains('completed')) return;
+  openPracticeModal(blockEl, planId, blockIdx);
 }
 
 // Check button (stopPropagation'd from block click): toggle complete state


### PR DESCRIPTION
## Summary
Closes #49

Implements the practice modal — a full-screen overlay that opens when you click a session block.

## What changed
- **Block click** now opens a focused overlay modal instead of loading the dashboard timer inline
- **Modal contains:** block title/description, independent timer (pre-loaded, not auto-started), metronome, PDF/book buttons
- **Independent timer** (`PM_TIMER`) — runs inside the modal without conflicting with the dashboard timer
- **Exit paths:**
  - Mark Complete → DynamoDB write fires, modal closes
  - Keep Practicing → adds 5 min, timer restarts
  - Come Back to This → flags block with amber indicator, modal closes
  - Backdrop click / Escape → clean dismiss, no state change
- **Session wrap-up:** last block completion shows note prompt before saving (Save & Finish / Skip Notes — both save)
- **Each block completion writes to DynamoDB immediately** — partial sessions are persisted
- **`stampBlockRefs()`** attaches week-map PDF refs to theory/ear blocks so the modal can render book buttons
- **`modal.js`** is a new standalone module — `progress.js` unchanged

## Files changed
| File | Change |
|---|---|
| `js/modal.js` | New — all modal logic |
| `js/session.js` | `activateBlock()` now opens modal; `stampBlockRefs()` added |
| `js/init.js` | Calls `stampBlockRefs()` on load |
| `index.html` | Modal HTML shell + `<script>` tag for modal.js |
| `css/styles.css` | Modal styles + come-back block state |

## Deferred (separate issues)
- Chapter-level checkboxes inside blocks → #50
- Milestone auto-calculation → #51
- Streak from backend → #52