### PR TITLE
feat(#52): streak and heatmap from DynamoDB backend

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -39,10 +39,10 @@ function init() {
     if (checkedItems[key]) row.classList.add('done');
   });
 
-  // Restore block states and build streak
+  // Restore block states and build streak (async — hydrates from DynamoDB)
   restoreBlockStates();
   stampBlockRefs();
-  buildStreakCard();
+  buildStreakCard(); // async — updates streak/heatmap when backend responds
   checkSessionComplete();
   setTimeout(timerLoadSession, 100);
 

--- a/js/session.js
+++ b/js/session.js
@@ -169,6 +169,12 @@ function checkSessionComplete() {
     if (card) card.appendChild(banner);
   }
   banner.classList.toggle('visible', allDone);
-  if (allDone) logPracticeDay(true);
+  if (allDone) {
+    // Write session record to DynamoDB (replaces localStorage logPracticeDay)
+    const notes = (document.getElementById('session-notes') || {}).value || '';
+    saveSession(blocks.length, notes).catch(e => console.warn('saveSession failed:', e));
+    // Refresh streak card from backend
+    buildStreakCard();
+  }
 }
 

--- a/js/streak.js
+++ b/js/streak.js
@@ -2,22 +2,9 @@
 // STREAK & HEATMAP
 // ═══════════════════════════════════════════
 
-function getPracticeDays() {
-  return JSON.parse(localStorage.getItem('ngc-practice-days') || '[]');
-}
-function savePracticeDays(days) {
-  localStorage.setItem('ngc-practice-days', JSON.stringify(days));
-}
-
-function logPracticeDay(silent) {
-  const today = getTodayKey();
-  const days = getPracticeDays();
-  if (!days.includes(today)) {
-    days.push(today);
-    savePracticeDays(days);
-  }
-  buildStreakCard();
-}
+// localStorage-based practice day tracking retired in #52.
+// Session records now written to DynamoDB via saveSession() in session.js.
+// Streak and heatmap are derived from backend data via calcStreakFromBackend().
 
 function calcStreaks(days) {
   const daySet = new Set(days);
@@ -47,18 +34,25 @@ function calcStreaks(days) {
   return { streak, longest };
 }
 
-function buildStreakCard() {
-  const days = getPracticeDays();
-  const daySet = new Set(days);
-  const today = getTodayKey();
-  const { streak, longest } = calcStreaks(days);
+async function buildStreakCard() {
+  let practiceDays = [];
+  let current = 0, longest = 0;
+
+  try {
+    const result = await calcStreakFromBackend();
+    practiceDays = result.practiceDays || [];
+    current = result.current || 0;
+    longest = result.longest || 0;
+  } catch (e) {
+    console.warn('buildStreakCard: backend unavailable, showing zeros', e);
+  }
 
   const el = (id) => document.getElementById(id);
-  if (el('streak-count')) el('streak-count').textContent = streak;
+  if (el('streak-count')) el('streak-count').textContent = current;
   if (el('streak-longest')) el('streak-longest').textContent = longest;
-  if (el('streak-total')) el('streak-total').textContent = days.length;
+  if (el('streak-total')) el('streak-total').textContent = practiceDays.length;
 
-  buildHeatmap(daySet);
+  buildHeatmap(new Set(practiceDays));
 }
 
 function buildHeatmap(daySet) {

--- a/js/theme.js
+++ b/js/theme.js
@@ -352,7 +352,8 @@ function settingsDismissConfirm(id) {
 
 function settingsDoAction(id) {
   if (id === 'clear-streak') {
-    localStorage.removeItem('ngc-practice-days');
+    // ngc-practice-days localStorage key retired in #52 — streak now lives in DynamoDB.
+    // Clear-streak action is a no-op for localStorage; DynamoDB records are preserved.
     buildStreakCard();
   } else if (id === 'reset-curriculum') {
     [1,2,3,4,5].forEach(p => localStorage.removeItem(`ngc-curriculum-p${p}`));
@@ -370,7 +371,6 @@ function settingsDoAction(id) {
 function settingsExportData() {
   const data = {
     exportDate: new Date().toISOString(),
-    practiceDays: JSON.parse(localStorage.getItem('ngc-practice-days') || '[]'),
     songStatuses: getAllSongStatuses(),
     curriculum: {},
     notes: localStorage.getItem('ngc-notes') || '',

--- a/js/ui.js
+++ b/js/ui.js
@@ -168,10 +168,7 @@ async function practiceLogSave() {
     console.warn('practiceLogSave: saveSession failed', e);
   }
 
-  // Also log the practice day for streak
-  logPracticeDay(true);
-
-  // Refresh streak display
+  // Refresh streak display from backend
   buildStreakCard();
 
   // Reset card to default state


### PR DESCRIPTION
## Summary

Closes #52 — progress history / streak from backend. Part of Epic #46.

Wires the existing `calcStreakFromBackend()` and `saveSession()` functions in `progress.js` into the streak card and session completion flow. The localStorage-based streak tracking is retired.

## What changed

### `streak.js`
- `buildStreakCard()` converted to `async` — calls `calcStreakFromBackend()` instead of reading `localStorage`
- `getPracticeDays()`, `savePracticeDays()`, and `logPracticeDay()` removed
- Graceful fallback: if backend unavailable, streak shows zeros rather than crashing
- `calcStreaks()` pure function and its Vitest tests are **untouched**

### `session.js`
- `checkSessionComplete()` now calls `saveSession(blocks.length, notes)` when all blocks are done
- `buildStreakCard()` called after save to refresh heatmap from backend data
- `logPracticeDay()` call removed

### `ui.js`
- Practice Log card save: redundant `logPracticeDay()` call removed (`saveSession()` already called above it)

### `theme.js`
- `clear-streak` settings action: `localStorage.removeItem` replaced with no-op comment (DynamoDB records preserved)
- Settings export: `practiceDays` field removed (was always `[]` post-migration)

### `init.js`
- Comment updated to reflect async streak hydration

## What was NOT changed
- `calcStreaks()` pure function and Vitest tests — untouched
- `buildHeatmap()` — no changes
- DynamoDB infrastructure — already existed in `progress.js`

## Testing checklist
- [ ] Load app — streak card renders
- [ ] Complete all blocks — session banner appears, DynamoDB write fires, streak refreshes
- [ ] Reload page — streak/heatmap reflects backend data
- [ ] Settings → clear-streak — no JS error